### PR TITLE
Changed visibility of RemoteClient subclass

### DIFF
--- a/src/com/blogspot/debukkitsblog/net/Server.java
+++ b/src/com/blogspot/debukkitsblog/net/Server.java
@@ -564,7 +564,7 @@ public abstract class Server {
 	 * A RemoteClient representating a client connected to this server storing an id
 	 * for identification and a socket for communication.
 	 */
-	private class RemoteClient {
+	protected class RemoteClient {
 		private String id;
 		private String group;
 		private Socket socket;


### PR DESCRIPTION
onClientRemoved could not be overwritten so far, because the visibility of the Server#RemoteClient subclass was private. Changed it to protected.